### PR TITLE
Normalize SvABA VCF sample names via bcftools reheader

### DIFF
--- a/docs/GERMLINE_SV_README.md
+++ b/docs/GERMLINE_SV_README.md
@@ -55,6 +55,23 @@ the -t flag), a single SV and a single indel VCF will be emitted.
 
 A BWA-MEM index reference genome must also be supplied with -G.
 
+#### SvABA sample-name normalization
+
+SvABA can emit VCF sample columns using a staged input path (for example, a
+localized BAM/CRAM path) instead of a user-friendly sample identifier. The
+workflow includes a post-call normalization step that rewrites the single
+sample column in SvABA VCF outputs before downstream annotation.
+
+- Tool used: `tools/bcftools_reheader_single_sample.cwl`
+- Applied to:
+    - SvABA germline SV VCF
+    - SvABA germline INDEL VCF
+- Sample name source:
+    - `biospecimen_name` (for BA-style sample IDs)
+
+This keeps SvABA sample naming aligned with SNV outputs and avoids path-like
+sample names in final outputs.
+
 ### AnnotSV
 
 AnnotSV is a program designed for annotating and ranking Structural Variations
@@ -76,8 +93,8 @@ potential pathogenicity and ii) filter out SV potential false positives.
     - `manta_svs`: Structural Variants called by Manta
     - `manta_indels`: Small INDELs called by Manta
 - SvABA
-    - `svaba_svs`: Structural Variants called by SvABA
-    - `svaba_indels`: Small INDELs called by SvABA
+    - `svaba_svs`: Structural Variants called by SvABA (sample column normalized)
+    - `svaba_indels`: Small INDELs called by SvABA (sample column normalized)
 - AnnotSV
     - `manta_annotated_svs`: This file contains all records from the `manta_svs` that AnnotSV could annotate.
     - `svaba_annotated_svs`: This file contains all records from the `svaba_svs` that AnnotSV could annotate.

--- a/tools/bcftools_reheader_single_sample.cwl
+++ b/tools/bcftools_reheader_single_sample.cwl
@@ -1,0 +1,57 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: bcftools_reheader_single_sample
+doc: |
+  Rename the single sample column in a VCF/VCF.GZ to a provided sample name,
+  then bgzip and index the output.
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: ShellCommandRequirement
+  - class: ResourceRequirement
+    ramMin: $(inputs.ram * 1000)
+    coresMin: $(inputs.cpu)
+  - class: DockerRequirement
+    dockerPull: 'staphb/bcftools:1.17'
+baseCommand: ["/bin/bash", "-c"]
+arguments:
+  - position: 1
+    shellQuote: false
+    valueFrom: |-
+      set -eo pipefail
+
+      bcftools query -l $(inputs.input_vcf.path) | head -n 1 | awk -v new_name="$(inputs.sample_name)" '{print $1"\t"new_name}' > reheader_samples.tsv
+      if [ ! -s reheader_samples.tsv ]; then
+        echo "ERROR: Could not determine sample name from input VCF: $(inputs.input_vcf.basename)" >&2
+        exit 1
+      fi
+
+      bcftools reheader --samples reheader_samples.tsv --output $(inputs.output_filename) $(inputs.input_vcf.path)
+      bcftools index --threads $(inputs.cpu) --tbi --force $(inputs.output_filename)
+inputs:
+  input_vcf:
+    type: File
+    secondaryFiles:
+      - {pattern: '.tbi', required: false}
+      - {pattern: '.csi', required: false}
+    doc: "Input VCF.GZ to reheader"
+  sample_name:
+    type: string
+    doc: "Desired sample name for the last VCF column"
+  output_filename:
+    type: string
+    doc: "Output bgzipped VCF filename"
+  cpu:
+    type: int?
+    default: 4
+    doc: "Number of CPUs to allocate to this task."
+  ram:
+    type: int?
+    default: 16
+    doc: "GB size of RAM to allocate to this task."
+outputs:
+  output_vcf_gz:
+    type: File
+    outputBinding:
+      glob: $(inputs.output_filename)
+    secondaryFiles:
+      - .tbi

--- a/workflows/kfdrc-germline-sv-wf.cwl
+++ b/workflows/kfdrc-germline-sv-wf.cwl
@@ -141,6 +141,7 @@ inputs:
     doc: |
       The genome build of the reference fasta. AnnotSV is capable of annotating the following genomes: "GRCh37","GRCh38","mm9","mm10".
   output_basename: {type: 'string?', doc: "String value to use as basename for outputs"}
+  biospecimen_name: {type: 'string', doc: "String name of biospecimen to use as sample name in output VCFs"}
   run_svaba: {type: 'boolean?', default: true, doc: "Run the SVaba module?"}
   run_manta: {type: 'boolean?', default: true, doc: "Run the Manta module?"}
   svaba_cpu: {type: 'int?', doc: "CPUs to allocate to SVaba"}
@@ -148,8 +149,8 @@ inputs:
   manta_cpu: {type: 'int?', doc: "CPUs to allocate to Manta"}
   manta_ram: {type: 'int?', doc: "GB of RAM to allocate to Manta"}
 outputs:
-  svaba_indels: {type: 'File?', outputSource: svaba/germline_indel_vcf_gz, doc: "VCF containing INDEL variants called by SvABA"}
-  svaba_svs: {type: 'File?', outputSource: svaba/germline_sv_vcf_gz, doc: "VCF containing SV called by SvABA"}
+  svaba_indels: {type: 'File?', outputSource: svaba_reheader_indel/output_vcf_gz, doc: "VCF containing INDEL variants called by SvABA"}
+  svaba_svs: {type: 'File?', outputSource: svaba_reheader_sv/output_vcf_gz, doc: "VCF containing SV called by SvABA"}
   svaba_annotated_indels: {type: 'File?', outputSource: annotsv_svaba_indel/annotated_calls, doc: "TSV containing annotated variants
       from the svaba_indels output"}
   svaba_annotated_svs: {type: 'File?', outputSource: annotsv_svaba_sv/annotated_calls, doc: "TSV containing annotated variants from
@@ -179,6 +180,30 @@ steps:
       cores: svaba_cpu
       ram: svaba_ram
     out: [alignments, bps, contigs, log, germline_indel_vcf_gz, germline_indel_unfiltered_vcf_gz, germline_sv_vcf_gz, germline_sv_unfiltered_vcf_gz]
+  svaba_reheader_indel:
+    run: ../tools/bcftools_reheader_single_sample.cwl
+    when: $(inputs.run_svaba)
+    in:
+      run_svaba: run_svaba
+      input_vcf: svaba/germline_indel_vcf_gz
+      sample_name: biospecimen_name
+      output_filename:
+        source: svaba/germline_indel_vcf_gz
+        valueFrom: $(self.basename)
+      cpu: svaba_cpu
+    out: [output_vcf_gz]
+  svaba_reheader_sv:
+    run: ../tools/bcftools_reheader_single_sample.cwl
+    when: $(inputs.run_svaba)
+    in:
+      run_svaba: run_svaba
+      input_vcf: svaba/germline_sv_vcf_gz
+      sample_name: biospecimen_name
+      output_filename:
+        source: svaba/germline_sv_vcf_gz
+        valueFrom: $(self.basename)
+      cpu: svaba_cpu
+    out: [output_vcf_gz]
   manta:
     run: ../tools/manta.cwl
     when: $(inputs.run_manta)
@@ -201,7 +226,7 @@ steps:
     in:
       run_svaba: run_svaba
       annotations_dir_tgz: annotsv_annotations_dir
-      sv_input_file: svaba/germline_indel_vcf_gz
+      sv_input_file: svaba_reheader_indel/output_vcf_gz
       genome_build: annotsv_genome_build
     out: [annotated_calls, unannotated_calls]
   annotsv_svaba_sv:
@@ -210,7 +235,7 @@ steps:
     in:
       run_svaba: run_svaba
       annotations_dir_tgz: annotsv_annotations_dir
-      sv_input_file: svaba/germline_sv_vcf_gz
+      sv_input_file: svaba_reheader_sv/output_vcf_gz
       genome_build: annotsv_genome_build
     out: [annotated_calls, unannotated_calls]
   annotsv_manta_indel:

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -620,6 +620,7 @@ steps:
       indexed_reference_fasta: indexed_reference_fasta
       germline_reads: aligned_reads
       output_basename: output_basename
+      biospecimen_name: biospecimen_name
       annotsv_annotations_dir: annotsv_annotations_dir
       annotsv_genome_build: annotsv_genome_build
       svaba_cpu: svaba_cpu


### PR DESCRIPTION
**Summary**
SvABA was emitting sample file full path to the VCF and carried over to the final annotated file, which was inconsistent with SNV VCFs. This PR adds a post-call reheader step so SvABA VCF headers use the BA-style biospecimen ID.

**What Changed**

- Added a new CWL tool: `bcftools_reheader_single_sample.cwl`
- Updated SV subworkflow to reheader both SvABA outputs (*.sv.vcf.gz and *.indel.vcf.gz) before downstream use: `kfdrc-germline-sv-wf.cwl`
- Wired `biospecimen_name` into the SV workflow call at top level: `kfdrc-germline-variant-wf.cwl`
- Updated SV module docs to reflect current behavior: `GERMLINE_SV_README.md`

**Validation**
- Local `cwltool` run produced the expected outputs.
- Cavatica task re-run also produced the expected outputs. https://cavatica.sbgenomics.com/u/childrens-bti/kf-germline-workflow-cnh-dev/tasks/5614e867-8c44-4099-998b-20337f9ef118/