### PR TITLE
Fix Manta SV annotation workflow

### DIFF
--- a/workflows/kfdrc-germline-sv-wf.cwl
+++ b/workflows/kfdrc-germline-sv-wf.cwl
@@ -156,9 +156,7 @@ outputs:
   svaba_annotated_svs: {type: 'File?', outputSource: annotsv_svaba_sv/annotated_calls, doc: "TSV containing annotated variants from
       the svaba_svs output"}
   manta_indels: {type: 'File?', outputSource: manta/small_indels, doc: "VCF containing INDEL variants called by Manta"}
-  manta_svs: {type: 'File?', outputSource: manta/output_sv, doc: "VCF containing SV called by Manta"}
-  manta_annotated_indels: {type: 'File?', outputSource: annotsv_manta_indel/annotated_calls, doc: "TSV containing annotated variants
-      from the manta_indels output"}
+  manta_svs: {type: 'File?', outputSource: manta_reheader_sv/output_vcf_gz, doc: "VCF containing SV called by Manta"}
   manta_annotated_svs: {type: 'File?', outputSource: annotsv_manta_sv/annotated_calls, doc: "TSV containing annotated variants from
       the manta_svs output"}
 steps:
@@ -220,6 +218,18 @@ steps:
       cores: manta_cpu
       ram: manta_ram
     out: [output_sv, small_indels]
+  manta_reheader_sv:
+    run: ../tools/bcftools_reheader_single_sample.cwl
+    when: $(inputs.run_manta)
+    in:
+      run_manta: run_manta
+      input_vcf: manta/output_sv
+      sample_name: biospecimen_name
+      output_filename:
+        source: manta/output_sv
+        valueFrom: $(self.basename)
+      cpu: manta_cpu
+    out: [output_vcf_gz]
   annotsv_svaba_indel:
     run: ../tools/annotsv.cwl
     when: $(inputs.run_svaba)
@@ -238,22 +248,13 @@ steps:
       sv_input_file: svaba_reheader_sv/output_vcf_gz
       genome_build: annotsv_genome_build
     out: [annotated_calls, unannotated_calls]
-  annotsv_manta_indel:
-    run: ../tools/annotsv.cwl
-    when: $(inputs.run_manta)
-    in:
-      run_manta: run_manta
-      annotations_dir_tgz: annotsv_annotations_dir
-      sv_input_file: manta/small_indels
-      genome_build: annotsv_genome_build
-    out: [annotated_calls, unannotated_calls]
   annotsv_manta_sv:
     run: ../tools/annotsv.cwl
     when: $(inputs.run_manta)
     in:
       run_manta: run_manta
       annotations_dir_tgz: annotsv_annotations_dir
-      sv_input_file: manta/output_sv
+      sv_input_file: manta_reheader_sv/output_vcf_gz
       genome_build: annotsv_genome_build
     out: [annotated_calls, unannotated_calls]
 hints:

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -654,5 +654,5 @@ $namespaces:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-germline-workflow-cnh/commits/v1.1.0'
+- id: 'https://github.com/childrens-bti/kf-germline-workflow-cnh/releases/tag/v1.1.0'
   label: github-release

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -30,7 +30,7 @@ doc: |+
 
   - [Ensembl VEP](https://github.com/Ensembl/ensembl-vep): `105`
   - [gnomAD](https://gnomad.broadinstitute.org/): `3.1.1`
-  - [AnnotSV](https://github.com/lgmgeo/AnnotSV/): `3.1.1`
+  - [AnnotSV](https://github.com/lgmgeo/AnnotSV/): `3.5.3`
 
 
   | Method    | CNV | SNV | SV | Annotation |
@@ -124,7 +124,7 @@ doc: |+
           - `intervar`: Intervar vcf-formatted file. Exonic SNVs only - for more comprehensive run InterVar. See docs for custom build instructions
   - Structural Variants
       - Annotation
-          - `annotsv_annotations_dir`: These annotations are simply those from the install-human-annotation installation process run during AnnotSV installation (see: https://github.com/lgmgeo/AnnotSV/#quick-installation). Specifically these are the annotations installed with v3.1.1 of the software. Newer or older annotations can be slotted in here as needed.
+          - `annotsv_annotations_dir`: These annotations are simply those from the install-human-annotation installation process run during AnnotSV installation (see: https://github.com/lgmgeo/AnnotSV/#quick-installation). Specifically these are the annotations installed with v3.5.3 of the software. Newer or older annotations can be slotted in here as needed.
 
   ## Output Files
 
@@ -473,8 +473,6 @@ outputs:
       output"}
   manta_indels: {type: 'File?', outputSource: sv/manta_indels, doc: "VCF containing INDEL variants called by Manta"}
   manta_svs: {type: 'File?', outputSource: sv/manta_svs, doc: "VCF containing SV called by Manta"}
-  manta_annotated_indels: {type: 'File?', outputSource: sv/manta_annotated_indels, doc: "TSV containing annotated variants from the
-      manta_indels output"}
   manta_annotated_svs: {type: 'File?', outputSource: sv/manta_annotated_svs, doc: "TSV containing annotated variants from the manta_svs
       output"}
 steps:
@@ -629,7 +627,7 @@ steps:
       manta_ram: manta_ram
       run_svaba: run_svaba
       run_manta: run_manta
-    out: [svaba_indels, svaba_svs, svaba_annotated_indels, svaba_annotated_svs, manta_indels, manta_svs, manta_annotated_indels, manta_annotated_svs]
+    out: [svaba_indels, svaba_svs, svaba_annotated_indels, svaba_annotated_svs, manta_indels, manta_svs, manta_annotated_svs]
 hints:
 - class: "sbg:maxNumberOfParallelInstances"
   value: 4

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -654,5 +654,5 @@ $namespaces:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-germline-workflow/releases/tag/v1.2.0'
+- id: 'https://github.com/childrens-bti/kf-germline-workflow-cnh/commits/v1.1.0'
   label: github-release

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -3,7 +3,7 @@ class: Workflow
 id: kfdrc-germline-variant-wf
 label: Kids First DRC Germline Variant Workflow
 doc: |+
-  # Kids First Data Resource Center Germline Variant Workflow
+  # Kids First Data Resource Center Germline Variant Workflow (CNH updates)
 
   <p align="center">
     <img src="https://github.com/d3b-center/d3b-research-workflows/raw/master/doc/kfdrc-logo-sm.png">


### PR DESCRIPTION
Closes #7 
## Summary
- reheader Manta diploid SV calls with the workflow biospecimen name
- use the reheadered Manta VCF for AnnotSV and the workflow SV output
- remove AnnotSV processing and output for Manta candidate small indels, which are ungenotyped sites-only candidates

## Validation
https://cavatica.sbgenomics.com/u/childrens-bti/fonseca-mci-wxs-harmonization/tasks/387aea1c-d934-4451-aba4-9cb71a7106cb/