### PR TITLE
Restore gnomAD v4.1.0 workflow updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "kf-annotation-tools"]
 	path = kf-annotation-tools
-	url = https://github.com/kids-first/kf-annotation-tools
+	url = https://github.com/childrens-bti/kf-annotation-tools-cnh.git

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Complete documentation can be found for the main workflow an its subworkflows he
     - [CNV Variant Workflow](./docs/GERMLINE_CNV_README.md)
     - [SNV Variant Workflow](./docs/GERMLINE_SNV_README.md)
       - Leverages the git submodule kf-annotation-tools for variant annotation with VEP 105 and gnomAD
+      - Supports both gnomAD v3.1.1 (default) and v4.1.0 - use the `gnomad_version` parameter to select
       - Details linked in the readme.
     - [SV Variant Workflow](./docs/GERMLINE_SV_README.md)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Complete documentation can be found for the main workflow an its subworkflows he
     - [CNV Variant Workflow](./docs/GERMLINE_CNV_README.md)
     - [SNV Variant Workflow](./docs/GERMLINE_SNV_README.md)
       - Leverages the git submodule kf-annotation-tools for variant annotation with VEP 105 and gnomAD
-      - Supports both gnomAD v3.1.1 (default) and v4.1.0 - use the `gnomad_version` parameter to select
+      - Supports both gnomAD v3.1.1 and v4.1.0 (both by default)
       - Details linked in the readme.
     - [SV Variant Workflow](./docs/GERMLINE_SV_README.md)
 

--- a/params/kfdrc-germline-variant-wf_inputs.yml
+++ b/params/kfdrc-germline-variant-wf_inputs.yml
@@ -155,10 +155,16 @@ snv_intervals_subdivision_mode: "BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVE
 # OPTIONAL INPUTS - SNV annotation resources
 # ============================================================================
 
-# echtvar annotations (gnomAD v3.1.1)
+# echtvar annotations (gnomAD - supports v3.1.1 and v4.1.0)
+# For v3.1.1 (default):
 echtvar_anno_zips:
   - class: File
     path: /home/ubuntu/kf-germline-workflow-cnh/data/references/gnomad.v3.1.1.custom.echtvar.zip
+
+# For v4.1.0, replace with:
+# echtvar_anno_zips:
+#   - class: File
+#     path: /home/ubuntu/kf-germline-workflow-cnh/data/references/gnomad.v4.1.0.custom.echtvar.zip
 
 # Optional annotation resources
 # clinvar_annotation_vcf:

--- a/params/kfdrc-germline-variant-wf_snv_gnomad_inputs.yml
+++ b/params/kfdrc-germline-variant-wf_snv_gnomad_inputs.yml
@@ -30,24 +30,24 @@ indexed_reference_fasta:
 # Aligned reads (BAM or CRAM format)
 aligned_reads:
   class: File
-  path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_20251031_6821ad23-9992-462a-8459-af5d66ba004b.cram
+  path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9.cram
   secondaryFiles:
     - class: File
-      path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_20251031_6821ad23-9992-462a-8459-af5d66ba004b.cram.crai
+      path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9.cram.crai
 
 # Input gVCF (optional - if provided, skips gVCF creation)
 input_gvcf:
   class: File
-  path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_20251031_6821ad23-9992-462a-8459-af5d66ba004b.g.vcf.gz
+  path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9.g.vcf.gz
   secondaryFiles:
     - class: File
-      path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_20251031_6821ad23-9992-462a-8459-af5d66ba004b.g.vcf.gz.tbi
+      path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9.g.vcf.gz.tbi
 
 # Output basename for all results
-output_basename: "BA_JC7Y94TC_4f72a221-39f4-4010-8bc9-6cac71345a88"
+output_basename: "BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9"
 
 # Biospecimen name
-biospecimen_name: "BA_JC7Y94TC"
+biospecimen_name: "BA_2ES4JBXY"
 
 # SNV calling regions (BED or INTERVALLIST format)
 snv_calling_regions:
@@ -128,9 +128,10 @@ one_thousand_genomes_resource_vcf:
       path: /home/ubuntu/kf-germline-workflow-cnh/data/references/1000G_phase1.snps.high_confidence.hg38.vcf.gz.tbi
 
 # Pedigree file for sample relationships
+# Using the actual ped file available for this sample (task ID is different here)
 ped:
   class: File
-  path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_4f72a221-39f4-4010-8bc9-6cac71345a88.peddy.peddy.ped
+  path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_3647f6b6-935f-4ace-bdfa-37b9625ddfd6.peddy.peddy.ped
 
 # VEP cache for annotation
 vep_cache:
@@ -310,10 +311,10 @@ run_manta: false        # Manta structural variant calling
 # If you already have a gVCF for this sample, provide it here to skip gVCF creation
 gvcf:
   class: File
-  path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_20251031_6821ad23-9992-462a-8459-af5d66ba004b.g.vcf.gz
+  path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9.g.vcf.gz
   secondaryFiles:
     - class: File
-      path: /home/ubuntu/kf-germline-workflow-cnh/data/bti-private-us-east-1-prd-gilbert-lab/harmonized/BA_JC7Y94TC_20251031_6821ad23-9992-462a-8459-af5d66ba004b.g.vcf.gz.tbi
+      path: /home/ubuntu/kf-germline-workflow-cnh/data/BA_2ES4JBXY_20251031_af404b98-557d-4da1-a7f4-d0c8d9c7f0c9.g.vcf.gz.tbi
 
 # ============================================================================
 # OPTIONAL INPUTS - VEP and annotation options

--- a/params/kfdrc-germline-variant-wf_snv_gnomad_inputs.yml
+++ b/params/kfdrc-germline-variant-wf_snv_gnomad_inputs.yml
@@ -271,16 +271,16 @@ maximum_number_events_per_sample: 120
 # ============================================================================
 
 # VEP resources
-vep_ram: 32  # in GB
-vep_cpu: 16  # number of cores
+vep_ram: 64  # in GB
+vep_cpu: 32  # number of cores
 
 # Strelka2 resources
 strelka2_cpu: 32
 strelka2_ram: 64  # in GB
 
 # Freebayes resources
-# freebayes_cpu: 4
-# freebayes_ram: 8
+freebayes_cpu: 32
+freebayes_ram: 64  # in GB
 
 # SvABA resources
 svaba_cpu: 24
@@ -295,13 +295,13 @@ svaba_ram: 64
 # ============================================================================
 
 # Enable/disable specific variant calling modules (default: all true)
-run_gatk_gcnv: false     # GATK Germline CNV calling
-run_cnvnator: false      # CNVnator CNV calling
-run_gatk_gsnv: false     # GATK Germline SNV calling
-run_freebayes: false     # Freebayes SNV calling
-run_strelka: false       # Strelka2 SNV calling
-run_svaba: true         # SvABA structural variant calling
-run_manta: false         # Manta structural variant calling
+run_gatk_gcnv: false    # GATK gCNV CNV calling (disabled for SNV-only)
+run_cnvnator: false     # CNVnator CNV calling (disabled for SNV-only)
+run_gatk_gsnv: true     # GATK Germline SNV calling
+run_freebayes: true     # Freebayes SNV calling
+run_strelka: true       # Strelka2 SNV calling
+run_svaba: false        # SvABA structural variant calling
+run_manta: false        # Manta structural variant calling
 
 # ============================================================================
 # OPTIONAL INPUTS - Pre-computed gVCF (skip gVCF generation)

--- a/subworkflows/freebayes.cwl
+++ b/subworkflows/freebayes.cwl
@@ -27,7 +27,7 @@ inputs:
   # Annotation
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: ['.tbi']}
-  echtvar_anno_zips: { type: 'File[]?', doc: "Annotation ZIP files for echtvar anno",
+  echtvar_anno_zips: { type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0.",
     "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6, name: gnomad.v3.1.1.custom.echtvar.zip}] } 
   # VEP-specific
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}

--- a/subworkflows/strelka2_germline.cwl
+++ b/subworkflows/strelka2_germline.cwl
@@ -28,7 +28,7 @@ inputs:
   # Annotation
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: ['.tbi'], doc: "additional bgzipped annotation vcf file"}
-  echtvar_anno_zips: { type: 'File[]?', doc: "Annotation ZIP files for echtvar anno",
+  echtvar_anno_zips: { type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0.",
     "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6, name: gnomad.v3.1.1.custom.echtvar.zip}] } 
 
   # VEP-specific

--- a/tools/bcftools_concat_sort_index.cwl
+++ b/tools/bcftools_concat_sort_index.cwl
@@ -15,19 +15,19 @@ baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       bcftools concat --output-type u
   - position: 10
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       | bcftools sort
   - position: 90
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       $(inputs.output_type == "b" || inputs.output_type == "z" ? "&& bcftools index --threads " + inputs.cpu : "")
   - position: 99
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       $(inputs.output_type == "b" || inputs.output_type == "z" ? inputs.output_filename : "")
 
 inputs:

--- a/tools/bcftools_merge.cwl
+++ b/tools/bcftools_merge.cwl
@@ -20,7 +20,7 @@ baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       bcftools merge --file-list files_to_merge.txt
 
 inputs:

--- a/tools/bcftools_view.cwl
+++ b/tools/bcftools_view.cwl
@@ -15,7 +15,7 @@ baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       bcftools view
 
 inputs:

--- a/tools/bcftools_view_index.cwl
+++ b/tools/bcftools_view_index.cwl
@@ -15,16 +15,16 @@ baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       bcftools view
   - position: 90
     prefix: "&&"
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       $(inputs.output_type == "b" || inputs.output_type == "z" ? "bcftools index --threads " + inputs.cpu : "echo DONE")
   - position: 99
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       $(inputs.output_type == "b" || inputs.output_type == "z" ? inputs.output_filename : "")
 
 inputs:

--- a/tools/bgzip_tabix.cwl
+++ b/tools/bgzip_tabix.cwl
@@ -15,20 +15,20 @@ baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       bgzip --stdout
   - position: 9
     shellQuote: false
     prefix: '>'
-    valueFrom: >
+    valueFrom: >-
       $(inputs.output_filename)
   - position: 10
     shellQuote: false
     prefix: '&&'
-    valueFrom: >
+    valueFrom: >-
       tabix
   - position: 18
-    valueFrom: >
+    valueFrom: >-
       $(inputs.output_filename)
 inputs:
   input_file: { type: 'File', inputBinding: { position: 8 }, doc: "Input gff, bed, sam, or vcf file." }

--- a/tools/freebayes_coverage_to_regions.cwl
+++ b/tools/freebayes_coverage_to_regions.cwl
@@ -25,12 +25,12 @@ baseCommand: []
 
 arguments:
   - position: 0
-    valueFrom: >
+    valueFrom: >-
       samtools depth -o depths.txt
   - position: 10
     prefix: "&&"
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       python3 coverage_to_regions.py depths.txt
 
 stdout: regions.txt

--- a/tools/gatk_intervallisttools.cwl
+++ b/tools/gatk_intervallisttools.cwl
@@ -20,7 +20,7 @@ arguments:
   - position: 10
     prefix: '&&'
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       $(inputs.subdivision_mode != null ? "" : "exit 0;")
       find ./temp_* -name *interval_list | sed 'p;s#temp_\([0-9]\+\).*#\1_scattered.interval_list#' | xargs -P $(inputs.cpu) -n 2 mv
 inputs:

--- a/tools/gatk_mergevcfs.cwl
+++ b/tools/gatk_mergevcfs.cwl
@@ -36,7 +36,6 @@ inputs:
       items: File
       inputBinding:
         prefix: -I
-    secondaryFiles: [{pattern: '.tbi', required: false}]
     inputBinding:
       position: 1
   reference_dict: File

--- a/tools/gatk_mergevcfs.cwl
+++ b/tools/gatk_mergevcfs.cwl
@@ -36,7 +36,7 @@ inputs:
       items: File
       inputBinding:
         prefix: -I
-    secondaryFiles: [.tbi]
+    secondaryFiles: [{pattern: '.tbi', required: false}]
     inputBinding:
       position: 1
   reference_dict: File

--- a/tools/samtools_view.cwl
+++ b/tools/samtools_view.cwl
@@ -15,7 +15,7 @@ baseCommand: []
 arguments:
   - position: 0
     shellQuote: false
-    valueFrom: >
+    valueFrom: >-
       samtools view
 inputs:
   # View Positional Arguments

--- a/tools/script_dynamicallycombineintervals.cwl
+++ b/tools/script_dynamicallycombineintervals.cwl
@@ -8,8 +8,8 @@ requirements:
 baseCommand: [python, -c]
 arguments:
   - position: 0
-    shellQuote: true
-    valueFrom: >-
+    shellQuote: false
+    valueFrom: |-
       def parse_interval(interval):
           colon_split = interval.split(":")
           chromosome = colon_split[0]
@@ -19,7 +19,7 @@ arguments:
           return chromosome, start, end
       def add_interval(chr, start, end, i):
           fn = "out-{:0>5d}.intervals".format(i)
-          lw = chr + ":" + str(start) + "-" + str(end) + "\n"
+          lw = chr + ":" + str(start) + "-" + str(end) + "\\n"
           with open(fn, "w") as fo:
               fo.writelines(lw)
           return chr, start, end

--- a/workflows/kfdrc-germline-snv-wf.cwl
+++ b/workflows/kfdrc-germline-snv-wf.cwl
@@ -247,9 +247,9 @@ inputs:
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
-  gnomad_version: {type: 'string?', doc: "gnomAD version to use for annotation. Supported values: 'v3.1.1' (default), 'v4.1.0'", default: "v3.1.1"}
-  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0. Use gnomad_version parameter to specify which version to use.", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
-        name: gnomad.v3.1.1.custom.echtvar.zip}]}
+      echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+        name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
+        name: gnomad.v4.1.0.custom.echtvar.zip}]}
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}
   vep_cache: {type: 'File', doc: "tar gzipped cache from ensembl/local converted cache", "sbg:suggestedValue": {class: File, path: 6332f8e47535110eb79c794f,
       name: homo_sapiens_merged_vep_105_indexed_GRCh38.tar.gz}}
@@ -470,7 +470,6 @@ steps:
         valueFrom: "single.gatk.genotyped.filtered.vep_105"
       bcftools_annot_clinvar_columns: bcftools_annot_clinvar_columns
       clinvar_annotation_vcf: clinvar_annotation_vcf
-      gnomad_version: gnomad_version
       echtvar_anno_zips: echtvar_anno_zips
       vep_ram: vep_ram
       vep_cores: vep_cpu

--- a/workflows/kfdrc-germline-snv-wf.cwl
+++ b/workflows/kfdrc-germline-snv-wf.cwl
@@ -247,9 +247,9 @@ inputs:
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
-      echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
-        name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
-        name: gnomad.v4.1.0.custom.echtvar.zip}]}
+  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+      name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
+      name: gnomad.v4.1.0.custom.echtvar.zip}]}
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}
   vep_cache: {type: 'File', doc: "tar gzipped cache from ensembl/local converted cache", "sbg:suggestedValue": {class: File, path: 6332f8e47535110eb79c794f,
       name: homo_sapiens_merged_vep_105_indexed_GRCh38.tar.gz}}

--- a/workflows/kfdrc-germline-snv-wf.cwl
+++ b/workflows/kfdrc-germline-snv-wf.cwl
@@ -247,7 +247,8 @@ inputs:
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
-  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+  gnomad_version: {type: 'string?', doc: "gnomAD version to use for annotation. Supported values: 'v3.1.1' (default), 'v4.1.0'", default: "v3.1.1"}
+  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0. Use gnomad_version parameter to specify which version to use.", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
         name: gnomad.v3.1.1.custom.echtvar.zip}]}
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}
   vep_cache: {type: 'File', doc: "tar gzipped cache from ensembl/local converted cache", "sbg:suggestedValue": {class: File, path: 6332f8e47535110eb79c794f,
@@ -469,6 +470,7 @@ steps:
         valueFrom: "single.gatk.genotyped.filtered.vep_105"
       bcftools_annot_clinvar_columns: bcftools_annot_clinvar_columns
       clinvar_annotation_vcf: clinvar_annotation_vcf
+      gnomad_version: gnomad_version
       echtvar_anno_zips: echtvar_anno_zips
       vep_ram: vep_ram
       vep_cores: vep_cpu

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -369,9 +369,9 @@ inputs:
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
-      echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
-          name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
-          name: gnomad.v4.1.0.custom.echtvar.zip}]}
+  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+        name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
+        name: gnomad.v4.1.0.custom.echtvar.zip}]}
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}
   vep_cache: {type: 'File', doc: "tar gzipped cache from ensembl/local converted cache", "sbg:suggestedValue": {class: File, path: 6332f8e47535110eb79c794f,
       name: homo_sapiens_merged_vep_105_indexed_GRCh38.tar.gz}}

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -655,5 +655,5 @@ $namespaces:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-germline-workflow-cnh/releases/tag/v1.1.0'
+- id: 'https://github.com/childrens-bti/kf-germline-workflow-cnh/releases/tag/v2.0.0'
   label: github-release

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -1,7 +1,7 @@
 cwlVersion: v1.2
 class: Workflow
 id: kfdrc-germline-variant-wf
-label: Kids First DRC Germline Variant Workflow
+label: Kids First DRC Germline Variant Workflow (CNH updates)
 doc: |+
   # Kids First Data Resource Center Germline Variant Workflow
 
@@ -29,7 +29,7 @@ doc: |+
   ### Annotators
 
   - [Ensembl VEP](https://github.com/Ensembl/ensembl-vep): `105`
-  - [gnomAD](https://gnomad.broadinstitute.org/): `3.1.1` (default) or `4.1.0` (configurable via `gnomad_version` parameter)
+    - [gnomAD](https://gnomad.broadinstitute.org/): `3.1.1` and `4.1.0` (both by default)
   - [AnnotSV](https://github.com/lgmgeo/AnnotSV/): `3.1.1`
 
 
@@ -114,8 +114,7 @@ doc: |+
 
           Recommended:
           - `vep_cache`: TAR.GZ cache from ensembl/local converted cache
-          - `echtvar_anno_zips`: echtvar-formatted gnomAD reference file. Supports both v3.1.1 (default) and v4.1.0. See annotation docs for more info
-          - `gnomad_version`: String specifying which gnomAD version to use: 'v3.1.1' (default) or 'v4.1.0'
+          - `echtvar_anno_zips`: echtvar-formatted gnomAD reference files. Supports both v3.1.1 and v4.1.0 (both by default). See annotation docs for more info
 
           Optional:
           - `clinvar_annotation_vcf`: ClinVar VCF used for annotation
@@ -370,9 +369,9 @@ inputs:
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
-  gnomad_version: {type: 'string?', doc: "gnomAD version to use for annotation. Supported values: 'v3.1.1' (default), 'v4.1.0'", default: "v3.1.1"}
-  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0. Use gnomad_version parameter to specify which version to use.", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
-        name: gnomad.v3.1.1.custom.echtvar.zip}]}
+      echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+          name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
+          name: gnomad.v4.1.0.custom.echtvar.zip}]}
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}
   vep_cache: {type: 'File', doc: "tar gzipped cache from ensembl/local converted cache", "sbg:suggestedValue": {class: File, path: 6332f8e47535110eb79c794f,
       name: homo_sapiens_merged_vep_105_indexed_GRCh38.tar.gz}}
@@ -595,7 +594,6 @@ steps:
       genomicsdbimport_extra_args: genomicsdbimport_extra_args
       bcftools_annot_clinvar_columns: bcftools_annot_clinvar_columns
       clinvar_annotation_vcf: clinvar_annotation_vcf
-      gnomad_version: gnomad_version
       echtvar_anno_zips: echtvar_anno_zips
       vep_buffer_size: vep_buffer_size
       vep_cache: vep_cache
@@ -658,5 +656,5 @@ $namespaces:
 - VCF
 - VEP
 "sbg:links":
-- id: 'https://github.com/kids-first/kf-germline-workflow/releases/tag/v1.2.0'
+- id: 'https://github.com/childrens-bti/kf-germline-workflow-cnh/tree/updates/gnomadv4.1.0'
   label: github-release

--- a/workflows/kfdrc-germline-variant-wf.cwl
+++ b/workflows/kfdrc-germline-variant-wf.cwl
@@ -29,7 +29,7 @@ doc: |+
   ### Annotators
 
   - [Ensembl VEP](https://github.com/Ensembl/ensembl-vep): `105`
-  - [gnomAD](https://gnomad.broadinstitute.org/): `3.1.1`
+  - [gnomAD](https://gnomad.broadinstitute.org/): `3.1.1` (default) or `4.1.0` (configurable via `gnomad_version` parameter)
   - [AnnotSV](https://github.com/lgmgeo/AnnotSV/): `3.1.1`
 
 
@@ -114,7 +114,8 @@ doc: |+
 
           Recommended:
           - `vep_cache`: TAR.GZ cache from ensembl/local converted cache
-          - `echtvar_anno_zips`: echtvar-formatted gnomAD v3.1.1 reference. See annotation docs for more info
+          - `echtvar_anno_zips`: echtvar-formatted gnomAD reference file. Supports both v3.1.1 (default) and v4.1.0. See annotation docs for more info
+          - `gnomad_version`: String specifying which gnomAD version to use: 'v3.1.1' (default) or 'v4.1.0'
 
           Optional:
           - `clinvar_annotation_vcf`: ClinVar VCF used for annotation
@@ -369,7 +370,8 @@ inputs:
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: [{pattern: '.tbi', required: true}], doc: "additional bgzipped annotation
       vcf file"}
-  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+  gnomad_version: {type: 'string?', doc: "gnomAD version to use for annotation. Supported values: 'v3.1.1' (default), 'v4.1.0'", default: "v3.1.1"}
+  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0. Use gnomad_version parameter to specify which version to use.", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
         name: gnomad.v3.1.1.custom.echtvar.zip}]}
   vep_buffer_size: {type: 'int?', default: 100000, doc: "Increase or decrease to balance speed and memory usage"}
   vep_cache: {type: 'File', doc: "tar gzipped cache from ensembl/local converted cache", "sbg:suggestedValue": {class: File, path: 6332f8e47535110eb79c794f,
@@ -593,6 +595,7 @@ steps:
       genomicsdbimport_extra_args: genomicsdbimport_extra_args
       bcftools_annot_clinvar_columns: bcftools_annot_clinvar_columns
       clinvar_annotation_vcf: clinvar_annotation_vcf
+      gnomad_version: gnomad_version
       echtvar_anno_zips: echtvar_anno_zips
       vep_buffer_size: vep_buffer_size
       vep_cache: vep_cache

--- a/workflows/kfdrc-single-sample-genotyping-wf.cwl
+++ b/workflows/kfdrc-single-sample-genotyping-wf.cwl
@@ -181,7 +181,8 @@ inputs:
 
   # Annotation
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
-  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+  gnomad_version: {type: 'string?', doc: "gnomAD version to use for annotation. Supported values: 'v3.1.1' (default), 'v4.1.0'", default: "v3.1.1"}
+  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0.", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
         name: gnomad.v3.1.1.custom.echtvar.zip}]}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: ['.tbi'], doc: "additional bgzipped annotation vcf file"}
   # VEP-specific

--- a/workflows/kfdrc-single-sample-genotyping-wf.cwl
+++ b/workflows/kfdrc-single-sample-genotyping-wf.cwl
@@ -181,9 +181,9 @@ inputs:
 
   # Annotation
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
-  gnomad_version: {type: 'string?', doc: "gnomAD version to use for annotation. Supported values: 'v3.1.1' (default), 'v4.1.0'", default: "v3.1.1"}
-  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0.", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
-        name: gnomad.v3.1.1.custom.echtvar.zip}]}
+      echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+        name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
+        name: gnomad.v4.1.0.custom.echtvar.zip}]}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: ['.tbi'], doc: "additional bgzipped annotation vcf file"}
   # VEP-specific
   vep_ram: {type: 'int?', default: 32, doc: "In GB, may need to increase this value depending on the size/complexity of input"}

--- a/workflows/kfdrc-single-sample-genotyping-wf.cwl
+++ b/workflows/kfdrc-single-sample-genotyping-wf.cwl
@@ -181,9 +181,9 @@ inputs:
 
   # Annotation
   bcftools_annot_clinvar_columns: {type: 'string?', doc: "csv string of columns from annotation to port into the input vcf", default: "INFO/ALLELEID,INFO/CLNDN,INFO/CLNDNINCL,INFO/CLNDISDB,INFO/CLNDISDBINCL,INFO/CLNHGVS,INFO/CLNREVSTAT,INFO/CLNSIG,INFO/CLNSIGCONF,INFO/CLNSIGINCL,INFO/CLNVC,INFO/CLNVCSO,INFO/CLNVI"}
-      echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
-        name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
-        name: gnomad.v4.1.0.custom.echtvar.zip}]}
+  echtvar_anno_zips: {type: 'File[]?', doc: "Annotation ZIP files for echtvar anno. Supports both gnomAD v3.1.1 and v4.1.0 (both by default).", "sbg:suggestedValue": [{class: File, path: 65c64d847dab7758206248c6,
+      name: gnomad.v3.1.1.custom.echtvar.zip}, {class: File, path: 6982705b5ddfaa35eff72c34,
+      name: gnomad.v4.1.0.custom.echtvar.zip}]}
   clinvar_annotation_vcf: {type: 'File?', secondaryFiles: ['.tbi'], doc: "additional bgzipped annotation vcf file"}
   # VEP-specific
   vep_ram: {type: 'int?', default: 32, doc: "In GB, may need to increase this value depending on the size/complexity of input"}


### PR DESCRIPTION
## Description

Restores the gnomAD v4.1.0 changes from PR #3 that never reached `master`.

PR #2 merged `updates/SvABA_AnnotSV` into `master` before PR #3 merged `updates/gnomadv4.1.0` into that feature branch. As a result, the later gnomAD merge commit (`2142c40`) remained only on `updates/SvABA_AnnotSV`.

This PR merges that missing history into the current `master` while preserving subsequent fixes and release metadata.

Key changes:

- Add gnomAD v4.1.0 echtvar annotation support alongside v3.1.1.
- Default applicable SNV workflows to both gnomAD reference archives.
- Update workflow descriptions, suggested inputs, documentation, and example parameters.
- Point the annotation-tools submodule URL to the CNH fork.
- Update the annotation-tools submodule from `af33fc7` to the fork's latest `master`, `0a1865c`.
- Restore related CWL fixes for command formatting, interval generation, and optional index handling.
- Preserve AnnotSV 3.5.3 and update release metadata to v2.0.0.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Breaking change: default annotations now include both gnomAD versions
- [x] Documentation update

## How Has This Been Tested?

- [x] `cwltool --validate workflows/kfdrc-germline-variant-wf.cwl`
- [x] `cwltool --validate workflows/kfdrc-germline-snv-wf.cwl`
- [x] `cwltool --validate workflows/kfdrc-single-sample-genotyping-wf.cwl`
- [x] `git diff --check master...HEAD`

All three workflows are valid CWL after the submodule update. Validation continues to report existing warnings for Seven Bridges extensions, external suggested-value paths, and conditional source/sink types.

## Review notes

Please pay particular attention to:

- The new dual gnomAD default and its effect on annotation output.
- The retained AnnotSV 3.5.3 version after resolving the historical merge overlap.
- The annotation-tools fork URL and updated `0a1865c` gitlink.
- CWL command-string and secondary-file changes restored from the original PR.

## Checklist

- [x] Changes are limited to restoring the missing gnomAD PR, resolving its overlap with later work, and updating its submodule dependency.
- [x] Documentation and example parameters were updated.
- [x] Current `master` changes were preserved.
- [x] CWL validation and whitespace checks pass.
